### PR TITLE
Update install_github ref to renamed fred repo

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install R packages
         run: |
           Rscript -e 'install.packages(c("remotes", "dplyr", "jsonlite", "stringr", "readr"))'
-          Rscript -e 'remotes::install_github("forrtproject/FReD")'
+          Rscript -e 'remotes::install_github("forrtproject/fred")'
 
       - name: Run preprocessing scripts
         run: |


### PR DESCRIPTION
## Summary

\`forrtproject/FReD\` was renamed to \`forrtproject/fred\` during the org-wide kebab-case migration. GitHub auto-redirects \`install_github(\"forrtproject/FReD\")\` to the new path, so this is *currently* working — but the source should reflect the canonical name. Independent of the master→main work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)